### PR TITLE
Remove uplink info dependency

### DIFF
--- a/ofnetPolicy.go
+++ b/ofnetPolicy.go
@@ -394,7 +394,7 @@ func (self *PolicyAgent) InitTables(nextTblId uint8) error {
 	egressSelectTableDefaultFlow, _ := self.egressSelectTable.NewFlow(ofctrl.FlowMatch{
 		Priority: FLOW_MISS_PRIORITY,
 	})
-	egressSelectTableDefaultFlow.Next(self.egressTier0Table)
+	egressSelectTableDefaultFlow.Next(self.ingressTier0Table)
 
 	egressTier0TableDefaultFlow, _ := self.egressTier0Table.NewFlow(ofctrl.FlowMatch{
 		Priority: FLOW_MISS_PRIORITY,


### PR DESCRIPTION
We can't get uplink port info directly, so, we change to use local endpoint
info to redirect flow, specifically:

  1) From local arp packets: send to the controller for learning
  2) From local IP packet: send to egressTier0Table, redirect other ip packets
     to ingressTier0Table